### PR TITLE
Derive Default for clock::SystemClock

### DIFF
--- a/src/clock.rs
+++ b/src/clock.rs
@@ -7,16 +7,11 @@ pub trait Clock {
 
 /// `SystemClock` uses the system's clock to get the current time.
 /// This Clock should be used for real use-cases.
+#[derive(Default)]
 pub struct SystemClock {}
 
 impl Clock for SystemClock {
     fn now(&self) -> Instant {
         Instant::now()
-    }
-}
-
-impl Default for SystemClock {
-    fn default() -> Self {
-        SystemClock {}
     }
 }


### PR DESCRIPTION
I'm not sure but probably `Debug` also should be derived for all types but it's a separate issue.