### PR TITLE
Support for use in WASM environments.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,12 @@ Retry operations with exponential backoff policy.
 travis-ci = { repository = "ihrwein/backoff" }
 
 [dependencies]
+instant = "0.1"
 rand = "0.6.5"
 
 [dev-dependencies]
 reqwest = "0.9.10"
+
+[features]
+default = []
+wasm-bindgen = ["instant/wasm-bindgen", "instant/now", "rand/wasm-bindgen"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,4 +24,5 @@ reqwest = "0.9.10"
 
 [features]
 default = []
-wasm-bindgen = ["instant/wasm-bindgen", "instant/now", "rand/wasm-bindgen"]
+stdweb = ["instant/stdweb", "rand/stdweb"]
+wasm-bindgen = ["instant/wasm-bindgen", "rand/wasm-bindgen"]

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ its [Golang port](https://github.com/cenkalti/backoff).
 
 Documentation: https://docs.rs/backoff
 
-Compile with feature `wasm-bindgen` for use in WASM environments.
+Compile with feature `wasm-bindgen` or `stdweb` for use in WASM environments. The `Operation` trait's default implementation of `retry_notify` is not yet supported, as it uses `std::thread::sleep`.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ its [Golang port](https://github.com/cenkalti/backoff).
 
 Documentation: https://docs.rs/backoff
 
+Compile with feature `wasm-bindgen` for use in WASM environments.
+
 ## Usage
 
 Just wrap your fallible operation into a closure, and call `retry` on it:

--- a/src/clock.rs
+++ b/src/clock.rs
@@ -1,4 +1,4 @@
-use std::time::Instant;
+use instant::Instant;
 
 /// Clock returns the current time.
 pub trait Clock {

--- a/src/exponential.rs
+++ b/src/exponential.rs
@@ -1,5 +1,5 @@
 use std::time::Duration;
-use std::time::Instant;
+use instant::Instant;
 
 use rand;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,6 +48,8 @@
 //!    9        | 12.807                   | [6.403, 19.210]
 //!   10        | 19.210                   | None
 //!
+
+extern crate instant;
 extern crate rand;
 
 mod error;

--- a/tests/exponential.rs
+++ b/tests/exponential.rs
@@ -1,11 +1,13 @@
 extern crate backoff;
+extern crate instant;
 
 use backoff::exponential::ExponentialBackoff;
 use backoff::{Clock, SystemClock};
 use backoff::backoff::Backoff;
 
+use instant::Instant;
 use std::cell::RefCell;
-use std::time::{Duration, Instant};
+use std::time::Duration;
 
 struct Inner {
     i: Duration,


### PR DESCRIPTION
Hey @ihrwein. This PR enables the use of this crate in WebAssembly environments.

Already tested the changes in a wasm-bindgen based context. Everything is working as expected. **Please note:** that this does not add support for the `Operation` trait's default implementation of `retry_notify`, which uses `std::thread::sleep`. Everything else should be just fine though.