### PR TITLE
Implement async retry

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,16 +17,17 @@ Retry operations with exponential backoff policy.
 travis-ci = { repository = "ihrwein/backoff" }
 
 [dependencies]
-async-std = "1.0"
-async-trait = "0.1"
-futures = "0.3"
 instant = "0.1"
 rand = "0.7"
+async-std = { version = "1.0", optional = true }
+async-trait = { version = "0.1", optional = true }
 
 [dev-dependencies]
 reqwest = { version = "0.10.1", features = ["json", "blocking"] }
+futures = { version = "0.3" }
 
 [features]
 default = []
+async = ["async-std", "async-trait"]
 stdweb = ["instant/stdweb", "rand/stdweb"]
 wasm-bindgen = ["instant/wasm-bindgen", "rand/wasm-bindgen"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "backoff"
 version = "0.1.7-alpha.0"
 authors = ["Tibor Benke <ihrwein@gmail.com>"]
+edition = "2018"
 license = "MIT/Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/ihrwein/backoff"
@@ -16,6 +17,9 @@ Retry operations with exponential backoff policy.
 travis-ci = { repository = "ihrwein/backoff" }
 
 [dependencies]
+async-std = "1.0"
+async-trait = "0.1"
+futures = "0.3"
 instant = "0.1"
 rand = "0.7"
 

--- a/src/async_retry.rs
+++ b/src/async_retry.rs
@@ -1,0 +1,212 @@
+use std::future::Future;
+use std::time::Duration;
+
+use async_trait::async_trait;
+
+use crate::backoff::Backoff;
+use crate::error::Error;
+
+pub trait AnyFn {
+    type Output;
+    fn call(&mut self) -> Self::Output;
+}
+
+impl<F, T> AnyFn for F
+where
+    F: FnMut() -> T,
+{
+    type Output = T;
+    fn call(&mut self) -> Self::Output {
+        self()
+    }
+}
+
+/// AsyncOperation is an async operation that can be retried if it fails.
+///
+/// [`AsyncOperation`]: backoff/trait.AsyncOperation.html#tymethod.next_backoff
+/// [`retry`]: backoff/trait.AsyncOperation.html#tymethod.retry
+/// [`retry_notify`]: backoff/trait.AsyncOperation.html#tymethod.retry_notify
+///
+/// AsyncOperation is an async operation that can be retried if it fails.
+#[async_trait]
+pub trait AsyncOperation<T, E>
+where
+    E: Sync + Send,
+{
+    /// call_op implements the effective operation.
+    async fn call_op(&mut self) -> Result<T, Error<E>>
+    where
+        T: 'async_trait,
+        E: 'async_trait;
+
+    /// Retries this operation according to the backoff policy.
+    /// backoff is reset before it is used.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use backoff::{ExponentialBackoff, async_retry::AsyncOperation, Error};
+    /// async fn f() -> Result<(), Error<&'static str>> {
+    ///     // Business logic...
+    ///     // Give up.
+    ///     Err(Error::Permanent("error"))
+    /// };
+    ///
+    /// # async fn main_task() {
+    /// let mut backoff = ExponentialBackoff::default();
+    /// let _ = f.retry(&mut backoff).await.err().unwrap();
+    /// # }
+    ///
+    /// # fn main() {
+    /// #    async_std::task::block_on(main_task());
+    /// # }
+    /// ```
+    ///
+    /// or using `Box::pin` if params are required
+    ///
+    /// ```rust
+    /// # use backoff::{ExponentialBackoff, async_retry::AsyncOperation, Error};
+    /// # use futures::future::BoxFuture;
+    /// # async fn main_task() {
+    /// let arg = "Async all the things!";
+    /// let mut f = || -> BoxFuture<Result<(), Error<&'static str>>> { Box::pin(async move {
+    ///     // Business logic...
+    ///     println!("{}", arg);
+    ///     // Give up.
+    ///     Err(Error::Permanent("error"))
+    /// })};
+    ///
+    /// let mut backoff = ExponentialBackoff::default();
+    /// let _ = f.retry(&mut backoff).await.err().unwrap();
+    /// # }
+    ///
+    /// # fn main() {
+    /// #    async_std::task::block_on(main_task());
+    /// # }
+    /// ```
+    async fn retry<B>(&mut self, backoff: &mut B) -> Result<T, Error<E>>
+    where
+        B: Backoff + Sync + Send,
+        T: 'async_trait,
+        E: 'async_trait,
+    {
+        let nop = |_, _| Box::pin(async {});
+        self.retry_notify(backoff, nop).await
+    }
+
+    /// Retries this operation according to the backoff policy.
+    /// Calls notify on failed attempts (in case of transient errors).
+    /// backoff is reset before it is used.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use backoff::{async_retry::AsyncOperation, Error};
+    /// # use backoff::backoff::Stop;
+    /// # use std::time::Duration;
+    /// # use std::fmt::Display;
+    /// async fn notify<E>(err: E, dur: Duration)
+    /// where
+    ///     E: Display
+    /// {
+    ///     println!("Error happened at {:?}: {}", dur, err);
+    /// }
+    ///
+    /// async fn f() -> Result<(), Error<&'static str>> {
+    ///     // Business logic...
+    ///     Err(Error::Transient("error"))
+    /// }
+    ///
+    /// # async fn main_task() {
+    /// let mut backoff = Stop{};
+    /// let _ = f.retry_notify(&mut backoff, notify).await.err().unwrap();
+    /// # }
+    ///
+    /// # fn main() {
+    /// #    async_std::task::block_on(main_task());
+    /// # }
+    /// ```
+    async fn retry_notify<B, N>(&mut self, backoff: &mut B, mut notify: N) -> Result<T, Error<E>>
+    where
+        B: Backoff + Send,
+        T: 'async_trait,
+        E: 'async_trait,
+        N: AsyncNotify<E> + Send,
+    {
+        backoff.reset();
+
+        loop {
+            let err = match self.call_op().await {
+                Ok(v) => return Ok(v),
+                Err(err) => err,
+            };
+
+            let err = match err {
+                Error::Permanent(err) => return Err(Error::Permanent(err)),
+                Error::Transient(err) => err,
+            };
+
+            let next = match backoff.next_backoff() {
+                Some(next) => next,
+                None => return Err(Error::Transient(err)),
+            };
+
+            notify.notify(err, next).await;
+            async_std::task::sleep(next).await;
+        }
+    }
+}
+
+#[async_trait]
+impl<T, E, F> AsyncOperation<T, E> for F
+where
+    E: Sync + Send,
+    F: AnyFn + Sync + Send,
+    F::Output: Future<Output = Result<T, Error<E>>> + Send,
+{
+    async fn call_op(&mut self) -> Result<T, Error<E>>
+    where
+        T: 'async_trait,
+        E: 'async_trait,
+    {
+        self.call().await
+    }
+}
+
+pub trait TwoArgFn<E> {
+    type Output;
+    fn call(&self, err: E, duration: Duration) -> Self::Output;
+}
+
+impl<F, E, T> TwoArgFn<E> for F
+where
+    F: Fn(E, Duration) -> T,
+{
+    type Output = T;
+    fn call(&self, err: E, duration: Duration) -> Self::Output {
+        self(err, duration)
+    }
+}
+
+/// AsyncNotify is called in [`retry_notify`](trait.AsyncOperation.html#method.retry_notify) in case of errors.
+#[async_trait]
+pub trait AsyncNotify<E> {
+    async fn notify(&mut self, err: E, duration: Duration)
+    where
+        E: 'async_trait;
+}
+
+#[async_trait]
+impl<E, F> AsyncNotify<E> for F
+where
+    E: Sync + Send,
+    F: TwoArgFn<E> + Sync + Send,
+    F::Output: Future<Output = ()> + Send,
+{
+    async fn notify(&mut self, err: E, duration: Duration)
+    where
+        E: 'async_trait,
+    {
+        self.call(err, duration).await
+    }
+}

--- a/src/async_retry.rs
+++ b/src/async_retry.rs
@@ -45,7 +45,7 @@ where
     /// # Examples
     ///
     /// ```rust
-    /// # use backoff::{ExponentialBackoff, async_retry::AsyncOperation, Error};
+    /// # use backoff::{ExponentialBackoff, AsyncOperation, Error};
     /// async fn f() -> Result<(), Error<&'static str>> {
     ///     // Business logic...
     ///     // Give up.
@@ -65,7 +65,7 @@ where
     /// or using `Box::pin` if params are required
     ///
     /// ```rust
-    /// # use backoff::{ExponentialBackoff, async_retry::AsyncOperation, Error};
+    /// # use backoff::{ExponentialBackoff, AsyncOperation, Error};
     /// # use futures::future::BoxFuture;
     /// # async fn main_task() {
     /// let arg = "Async all the things!";
@@ -101,7 +101,7 @@ where
     /// # Examples
     ///
     /// ```rust
-    /// # use backoff::{async_retry::AsyncOperation, Error};
+    /// # use backoff::{AsyncOperation, Error};
     /// # use backoff::backoff::Stop;
     /// # use std::time::Duration;
     /// # use std::fmt::Display;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,6 +54,7 @@ extern crate rand;
 
 mod error;
 mod retry;
+pub mod async_retry;
 pub mod backoff;
 pub mod exponential;
 pub mod default;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,7 +54,6 @@ extern crate rand;
 
 mod error;
 mod retry;
-pub mod async_retry;
 pub mod backoff;
 pub mod exponential;
 pub mod default;
@@ -63,6 +62,11 @@ mod clock;
 pub use crate::error::Error;
 pub use crate::clock::{Clock, SystemClock};
 pub use crate::retry::{Notify, Operation};
+
+#[cfg(feature = "async")]
+mod async_retry;
+#[cfg(feature = "async")]
+pub use crate::async_retry::{AsyncNotify, AsyncOperation};
 
 /// Exponential backoff policy with system's clock.
 ///


### PR DESCRIPTION
This is a rough cut of an async version of the Operation API.

There's lots to do to tidy it up, but I thought it was worth surfacing it early to see if it's something people would find useful.

Fixes: https://github.com/ihrwein/backoff/issues/10