### PR TITLE
Adapters for Future

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "backoff"
 version = "0.1.7-alpha.0"
+edition = "2018"
 authors = ["Tibor Benke <ihrwein@gmail.com>"]
 license = "MIT/Apache-2.0"
 readme = "README.md"
@@ -16,13 +17,25 @@ Retry operations with exponential backoff policy.
 travis-ci = { repository = "ihrwein/backoff" }
 
 [dependencies]
+async_std_1 = { package = "async-std", version = "1.6", optional = true }
+futures-core = { version = "0.3.3", default-features = false, optional = true }
 instant = "0.1"
+pin-project = { version = "0.4.21", optional = true }
 rand = "0.7"
+tokio_02 = { package = "tokio", version = "0.2.21", features = ["time"], optional = true }
 
 [dev-dependencies]
+async_std_1 = { package = "async-std", version = "1.6", features = ["attributes"] }
 reqwest = { version = "0.10.1", features = ["json", "blocking"] }
+tokio_02 = { package = "tokio", version = "0.2.21", features = ["macros", "time"] }
 
 [features]
 default = []
 stdweb = ["instant/stdweb", "rand/stdweb"]
 wasm-bindgen = ["instant/wasm-bindgen", "rand/wasm-bindgen"]
+tokio = ["futures-core", "pin-project", "tokio_02"]
+async-std = ["async_std_1", "futures-core", "pin-project"]
+
+[[example]]
+name = "async"
+required-features = ["tokio"]

--- a/examples/async.rs
+++ b/examples/async.rs
@@ -1,0 +1,20 @@
+extern crate tokio_02 as tokio;
+
+use backoff::{future::FutureOperation as _, ExponentialBackoff};
+
+async fn fetch_url(url: &str) -> Result<String, reqwest::Error> {
+    (|| async {
+        println!("Fetching {}", url);
+        Ok(reqwest::get(url).await?.text().await?)
+    })
+    .retry(ExponentialBackoff::default())
+    .await
+}
+
+#[tokio::main]
+async fn main() {
+    match fetch_url("https://www.rust-lang.org").await {
+        Ok(_) => println!("Successfully fetched"),
+        Err(err) => panic!("Failed to fetch: {}", err),
+    }
+}

--- a/examples/permanent_error.rs
+++ b/examples/permanent_error.rs
@@ -1,6 +1,3 @@
-extern crate backoff;
-extern crate reqwest;
-
 use backoff::{Error, ExponentialBackoff, Operation};
 use reqwest::Url;
 
@@ -16,7 +13,7 @@ fn fetch_url(url: &str) -> Result<String, Error<io::Error>> {
         println!("Fetching {}", url);
         let url = Url::parse(url)
             .map_err(new_io_err)
-            // Permanent errors need to be explicitly constucted.
+            // Permanent errors need to be explicitly constructed.
             .map_err(Error::Permanent)?;
 
         let mut resp = reqwest::blocking::get(url)
@@ -36,7 +33,7 @@ fn fetch_url(url: &str) -> Result<String, Error<io::Error>> {
 
 fn main() {
     match fetch_url("https::///wrong URL") {
-        Ok(_) => println!("Sucessfully fetched"),
+        Ok(_) => println!("Successfully fetched"),
         Err(err) => panic!("Failed to fetch: {}", err),
     }
 }

--- a/examples/retry.rs
+++ b/examples/retry.rs
@@ -1,6 +1,3 @@
-extern crate backoff;
-extern crate reqwest;
-
 use backoff::{Error, ExponentialBackoff, Operation};
 
 use std::io::Read;
@@ -21,7 +18,7 @@ fn fetch_url(url: &str) -> Result<String, Error<reqwest::Error>> {
 
 fn main() {
     match fetch_url("https://www.rust-lang.org") {
-        Ok(_) => println!("Sucessfully fetched"),
+        Ok(_) => println!("Successfully fetched"),
         Err(err) => panic!("Failed to fetch: {}", err),
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,21 +47,25 @@
 //!    8        |  8.538                   | [4.269, 12.807]
 //!    9        | 12.807                   | [6.403, 19.210]
 //!   10        | 19.210                   | None
-//!
 
-extern crate instant;
-extern crate rand;
+#[cfg(feature = "async-std")]
+extern crate async_std_1 as async_std;
+#[cfg(feature = "tokio")]
+extern crate tokio_02 as tokio;
 
-mod error;
-mod retry;
 pub mod backoff;
-pub mod exponential;
-pub mod default;
 mod clock;
+pub mod default;
+mod error;
+pub mod exponential;
+mod retry;
 
-pub use crate::error::Error;
 pub use crate::clock::{Clock, SystemClock};
+pub use crate::error::Error;
 pub use crate::retry::{Notify, Operation};
+
+#[cfg(any(feature = "tokio", feature = "async-std"))]
+pub use crate::retry::r#async::future;
 
 /// Exponential backoff policy with system's clock.
 ///

--- a/src/retry/async.rs
+++ b/src/retry/async.rs
@@ -1,0 +1,273 @@
+use std::{
+    future::Future,
+    pin::Pin,
+    task::{Context, Poll},
+};
+
+use futures_core::ready;
+use pin_project::pin_project;
+#[cfg(feature = "tokio")]
+use tokio::time::{delay_for, Delay};
+
+use crate::{backoff::Backoff, error::Error};
+
+use super::{NoopNotify, Notify};
+
+#[cfg(feature = "async-std")]
+type Delay = Pin<Box<dyn Future<Output = ()> + 'static + Send>>;
+
+#[cfg(feature = "async-std")]
+fn delay_for(duration: std::time::Duration) -> Delay {
+    Box::pin(async_std::task::sleep(duration))
+}
+
+pub mod future {
+    use super::*;
+
+    /// Retries given `operation` according to the [`Backoff`] policy.
+    /// [`Backoff`] is reset before it is used.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # #[cfg(feature = "async-std")]
+    /// # extern crate async_std_1 as async_std;
+    /// # #[cfg(feature = "tokio")]
+    /// # extern crate tokio_02 as tokio;
+    /// use backoff::{future, ExponentialBackoff};
+    ///
+    /// async fn f() -> Result<(), backoff::Error<&'static str>> {
+    ///     // Business logic...
+    ///     Err(backoff::Error::Permanent("error"))
+    /// }
+    ///
+    /// # #[cfg_attr(feature = "async-std", async_std::main)]
+    /// # #[cfg_attr(feature = "tokio", tokio::main)]
+    /// # async fn main() {
+    /// future::retry(ExponentialBackoff::default(), f).await.err().unwrap();
+    /// # }
+    /// ```
+    pub fn retry<I, E, Fn, B>(backoff: B, operation: Fn) -> Retry<B, NoopNotify, Fn, Fn::Fut>
+    where
+        B: Backoff,
+        Fn: FutureOperation<I, E>,
+    {
+        retry_notify(backoff, operation, NoopNotify)
+    }
+
+    /// Retries given `operation` according to the [`Backoff`] policy.
+    /// Calls `notify` on failed attempts (in case of [`Error::Transient`]).
+    /// [`Backoff`] is reset before it is used.
+    ///
+    /// # Async `notify`
+    ///
+    /// `notify` can be neither `async fn` or [`Future`]. If you need to perform some async
+    /// operations inside `notify`, consider to use `tokio::spawn` or `async_std::task::spawn`
+    /// for that.
+    ///
+    /// The reason behind this is that [`Retry`] future cannot be responsible for polling
+    /// `notify` future, because can easily be dropped _before_ `notify` is completed.
+    /// So, considering the fact that most of the time no async operations are required in
+    /// `notify`, it's up to the caller to decide how async `notify` should be performed.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # #[cfg(feature = "async-std")]
+    /// # extern crate async_std_1 as async_std;
+    /// # #[cfg(feature = "tokio")]
+    /// # extern crate tokio_02 as tokio;
+    /// use backoff::{future, backoff::Stop};
+    ///
+    /// async fn f() -> Result<(), backoff::Error<&'static str>> {
+    ///     // Business logic...
+    ///     Err(backoff::Error::Transient("error"))
+    /// }
+    ///
+    /// # #[cfg_attr(feature = "async-std", async_std::main)]
+    /// # #[cfg_attr(feature = "tokio", tokio::main)]
+    /// # async fn main() {
+    /// future::retry_notify(Stop {}, f, |e, dur| println!("Error happened at {:?}: {}", dur, e))
+    ///     .await
+    ///     .err()
+    ///     .unwrap();
+    /// # }
+    /// ```
+    pub fn retry_notify<I, E, Fn, B, N>(
+        mut backoff: B,
+        mut operation: Fn,
+        notify: N,
+    ) -> Retry<B, N, Fn, Fn::Fut>
+    where
+        B: Backoff,
+        Fn: FutureOperation<I, E>,
+        N: Notify<E>,
+    {
+        backoff.reset();
+        let fut = operation.call_op();
+        Retry {
+            backoff,
+            delay: None,
+            operation,
+            fut,
+            notify,
+        }
+    }
+
+    /// [`FutureOperation`] is a [`Future`] operation that can be retried if it fails with the
+    /// provided [`Backoff`].
+    ///
+    /// Note, that this should not be a [`Future`] itself, but rather something producing a
+    /// [`Future`] (a closure, for example).
+    pub trait FutureOperation<I, E> {
+        /// Type of [`Future`] that this [`FutureOperation`] produces.
+        type Fut: Future<Output = Result<I, Error<E>>>;
+
+        /// Calls this [`FutureOperation`] returning a [`Future`] to be executed.
+        fn call_op(&mut self) -> Self::Fut;
+
+        /// Retries this [`FutureOperation`] according to the [`Backoff`] policy.
+        /// [`Backoff`] is reset before it is used.
+        ///
+        /// # Example
+        ///
+        /// ```rust
+        /// # #[cfg(feature = "async-std")]
+        /// # extern crate async_std_1 as async_std;
+        /// # #[cfg(feature = "tokio")]
+        /// # extern crate tokio_02 as tokio;
+        /// use backoff::{future::FutureOperation as _, ExponentialBackoff};
+        ///
+        /// async fn f() -> Result<(), backoff::Error<&'static str>> {
+        ///     // Business logic...
+        ///     Err(backoff::Error::Permanent("error"))
+        /// }
+        ///
+        /// # #[cfg_attr(feature = "async-std", async_std::main)]
+        /// # #[cfg_attr(feature = "tokio", tokio::main)]
+        /// # async fn main() {
+        /// f.retry(ExponentialBackoff::default()).await.err().unwrap();
+        /// # }
+        /// ```
+        fn retry<B>(self, backoff: B) -> Retry<B, NoopNotify, Self, Self::Fut>
+        where
+            B: Backoff,
+            Self: Sized,
+        {
+            retry(backoff, self)
+        }
+
+        /// Retries this [`FutureOperation`] according to the [`Backoff`] policy.
+        /// Calls `notify` on failed attempts (in case of [`Error::Transient`]).
+        /// [`Backoff`] is reset before it is used.
+        ///
+        /// # Async `notify`
+        ///
+        /// `notify` can be neither `async fn` or [`Future`]. If you need to perform some async
+        /// operations inside `notify`, consider to use `tokio::spawn` or `async_std::task::spawn`
+        /// for that.
+        ///
+        /// The reason behind this is that [`Retry`] future cannot be responsible for polling
+        /// `notify` future, because can easily be dropped _before_ `notify` is completed.
+        /// So, considering the fact that most of the time no async operations are required in
+        /// `notify`, it's up to the caller to decide how async `notify` should be performed.
+        ///
+        /// # Example
+        ///
+        /// ```rust
+        /// # #[cfg(feature = "async-std")]
+        /// # extern crate async_std_1 as async_std;
+        /// # #[cfg(feature = "tokio")]
+        /// # extern crate tokio_02 as tokio;
+        /// use backoff::{future::FutureOperation as _, backoff::Stop};
+        ///
+        /// async fn f() -> Result<(), backoff::Error<&'static str>> {
+        ///     // Business logic...
+        ///     Err(backoff::Error::Transient("error"))
+        /// }
+        ///
+        /// # #[cfg_attr(feature = "async-std", async_std::main)]
+        /// # #[cfg_attr(feature = "tokio", tokio::main)]
+        /// # async fn main() {
+        /// f.retry_notify(Stop {}, |e, dur| println!("Error happened at {:?}: {}", dur, e))
+        ///     .await
+        ///     .err()
+        ///     .unwrap();
+        /// # }
+        /// ```
+        fn retry_notify<B, N>(self, backoff: B, notify: N) -> Retry<B, N, Self, Self::Fut>
+        where
+            B: Backoff,
+            N: Notify<E>,
+            Self: Sized,
+        {
+            retry_notify(backoff, self, notify)
+        }
+    }
+
+    impl<I, E, Fn, Fut> FutureOperation<I, E> for Fn
+    where
+        Fn: FnMut() -> Fut,
+        Fut: Future<Output = Result<I, Error<E>>>,
+    {
+        type Fut = Fut;
+
+        fn call_op(&mut self) -> Self::Fut {
+            self()
+        }
+    }
+}
+
+/// Retry implementation.
+#[pin_project]
+pub struct Retry<B, N, Fn, Fut> {
+    /// [`Backoff`] implementation to count next [`Retry::delay`] with.
+    backoff: B,
+
+    /// [`Future`] which delays execution before next [`Retry::operation`] invocation.
+    delay: Option<Delay>,
+
+    /// Operation to be retried. It must return [`Future`].
+    operation: Fn,
+
+    /// [`Future`] being resolved once [`Retry::operation`] is completed.
+    #[pin]
+    fut: Fut,
+
+    /// [`Notify`] implementation to track [`Retry`] ticks.
+    notify: N,
+}
+
+impl<B, N, Fn, Fut, I, E> Future for Retry<B, N, Fn, Fut>
+where
+    B: Backoff,
+    N: Notify<E>,
+    Fn: FnMut() -> Fut,
+    Fut: Future<Output = Result<I, Error<E>>>,
+{
+    type Output = Result<I, E>;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let mut this = self.project();
+
+        loop {
+            if this.delay.is_some() {
+                ready!(Pin::new(this.delay.as_mut().unwrap()).poll(cx));
+                let _ = this.delay.take();
+            }
+
+            match ready!(this.fut.as_mut().poll(cx)) {
+                Ok(v) => return Poll::Ready(Ok(v)),
+                Err(Error::Permanent(e)) => return Poll::Ready(Err(e)),
+                Err(Error::Transient(e)) => match this.backoff.next_backoff() {
+                    Some(duration) => {
+                        this.notify.notify(e, duration);
+                        this.delay.replace(delay_for(duration));
+                        this.fut.set((this.operation)());
+                    }
+                    None => return Poll::Ready(Err(e)),
+                },
+            }
+        }
+    }
+}

--- a/tests/exponential.rs
+++ b/tests/exponential.rs
@@ -1,9 +1,9 @@
 extern crate backoff;
 extern crate instant;
 
+use backoff::backoff::Backoff;
 use backoff::exponential::ExponentialBackoff;
 use backoff::{Clock, SystemClock};
-use backoff::backoff::Backoff;
 
 use instant::Instant;
 use std::cell::RefCell;

--- a/tests/retry.rs
+++ b/tests/retry.rs
@@ -1,8 +1,8 @@
 extern crate backoff;
 
+use backoff::Error;
 use backoff::ExponentialBackoff;
 use backoff::Operation;
-use backoff::Error;
 
 use std::io;
 
@@ -18,7 +18,10 @@ fn retry() {
                 return Ok(());
             }
 
-            Err(Error::Transient(io::Error::new(io::ErrorKind::Other, "err")))
+            Err(Error::Transient(io::Error::new(
+                io::ErrorKind::Other,
+                "err",
+            )))
         };
 
         let mut backoff = ExponentialBackoff::default();
@@ -31,7 +34,10 @@ fn retry() {
 #[test]
 fn permanent_error_immediately_returned() {
     let mut f = || -> Result<(), Error<io::Error>> {
-        Err(Error::Permanent(io::Error::new(io::ErrorKind::Other, "err")))
+        Err(Error::Permanent(io::Error::new(
+            io::ErrorKind::Other,
+            "err",
+        )))
     };
 
     let mut backoff = ExponentialBackoff::default();


### PR DESCRIPTION
Fixes #10 

This PR superseeds and provides alternative implementations for #12 and [backoff-futures](https://docs.rs/backoff-futures).

Thanks to @mchlrhw and @jakubadamw for their work! 🙇‍♂️

## Why it's better?

The main reasons were described [here](https://github.com/ihrwein/backoff/pull/12#issuecomment-655309476):
> 1. Because of using `async-trait` the wrapped future is either strictly `Send` (like in this PR), requiring downstream users to make their futures `Send`/`Sync` (farewell, `actix` runtime 🥺 and `Rc` stuff), or strictly `?Send` (by returning a `LocalBoxFuture`), making it litterally unspawnable on `tokio`/`async-std`.
> 2. It accepts `&mut Backoff`, _the hell!_ 😵. Rust is too bad with self-referential stuff. And if you somehow want to move the `Backoff`ed future somewhere - you just cannot, because you should move the `Backoff` too, because we hold only `&mut`-reference too it. It just complicates things _a lot_ without any real reason. It will be much better _to bake `Backoff` into the returned`Future`_ so it owns it.

So, this PR provides implementation, which is:
1. Totally `Send`/`Sync` transparent.  No `Send`/`Sync` hardcoding is involved. If you're using single-thread runtime, then you're allowed to use `Retry` with `Rc`/`RefCell` and other `!Send`/`!Sync`. If you're using multi-threaded runtime, then `Retry` will be `Send`/`Sync` whenever upstream `Future` type is `Send`/`Sync`.
2. Consumes `AsyncOperation` and `Backoff` making the result `Retry` future _movable_. So if you're want to return a `Retry`able operation from a function or even send it to another thread - it's dead simple without messing with borrowing and self-refenrential stuff.
3. Does not contain any redudant `Box`ing.
4. Supports both `tokio` and `async-std` runtimes.



## Further possibilities

Once this PR will be merged, I'll prepare the next one, for `Stream`.