### PR TITLE
Make the future::retry functions generic over the sleeper

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,18 +27,20 @@ tokio_1 = { package = "tokio", version = "1.0", features = ["time"], optional = 
 [dev-dependencies]
 async_std_1 = { package = "async-std", version = "1.6", features = ["attributes"] }
 reqwest = { version = "0.10.10", features = ["json", "blocking"] }
-tokio_1 = { package = "tokio", version = "1.0", features = ["macros", "time"] }
+tokio_1 = { package = "tokio", version = "1.0", features = ["macros", "time", "rt-multi-thread"] }
+futures-executor = "0.3"
 
 [features]
 default = []
 stdweb = ["instant/stdweb", "rand/stdweb"]
 wasm-bindgen = ["instant/wasm-bindgen", "rand/wasm-bindgen"]
-tokio = ["futures-core", "pin-project", "tokio_1"]
-async-std = ["async_std_1", "futures-core", "pin-project"]
+futures = ["futures-core", "pin-project"]
+tokio = ["futures", "tokio_1"]
+async-std = ["futures", "async_std_1"]
 
 [[example]]
 name = "async"
 required-features = ["tokio"]
 
 [package.metadata.docs.rs]
-features = ["tokio"]
+features = ["tokio", "async-std"]

--- a/examples/async.rs
+++ b/examples/async.rs
@@ -1,13 +1,12 @@
-extern crate tokio_02 as tokio;
+extern crate tokio_1 as tokio;
 
-use backoff::{future::FutureOperation as _, ExponentialBackoff};
+use backoff::ExponentialBackoff;
 
 async fn fetch_url(url: &str) -> Result<String, reqwest::Error> {
-    (|| async {
+    backoff::tokio::retry(ExponentialBackoff::default(), || async {
         println!("Fetching {}", url);
         Ok(reqwest::get(url).await?.text().await?)
     })
-    .retry(ExponentialBackoff::default())
     .await
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,11 +48,6 @@
 //!    9        | 12.807                   | [6.403, 19.210]
 //!   10        | 19.210                   | None
 
-#[cfg(feature = "async-std")]
-extern crate async_std_1 as async_std;
-#[cfg(feature = "tokio")]
-extern crate tokio_1 as tokio;
-
 pub mod backoff;
 mod clock;
 pub mod default;
@@ -64,8 +59,13 @@ pub use crate::clock::{Clock, SystemClock};
 pub use crate::error::Error;
 pub use crate::retry::{Notify, Operation};
 
-#[cfg(any(feature = "tokio", feature = "async-std"))]
+#[cfg(feature = "futures")]
 pub use crate::retry::r#async::future;
+
+#[cfg(feature = "async-std")]
+pub use crate::retry::r#async::async_std;
+#[cfg(feature = "tokio")]
+pub use crate::retry::r#async::tokio;
 
 /// Exponential backoff policy with system's clock.
 ///

--- a/src/retry.rs
+++ b/src/retry.rs
@@ -1,4 +1,4 @@
-#[cfg(any(feature = "tokio", feature = "async-std"))]
+#[cfg(feature = "futures")]
 pub mod r#async;
 
 use std::thread;

--- a/src/retry/async.rs
+++ b/src/retry/async.rs
@@ -2,6 +2,7 @@ use std::{
     future::Future,
     pin::Pin,
     task::{Context, Poll},
+    time::Duration,
 };
 
 use futures_core::ready;
@@ -11,64 +12,66 @@ use crate::{backoff::Backoff, error::Error};
 
 use super::{NoopNotify, Notify};
 
-// time::Sleep in tokio 1.0 is Unpin
-#[cfg(feature = "tokio")]
-type Sleep = Pin<Box<tokio::time::Sleep>>;
-#[cfg(feature = "async-std")]
-type Sleep = Pin<Box<dyn Future<Output = ()> + 'static + Send>>;
-
-fn sleep(duration: std::time::Duration) -> Sleep {
-    #[cfg(feature = "async-std")]
-    use async_std::task::sleep;
-    #[cfg(feature = "tokio")]
-    use tokio::time::sleep;
-
-    Box::pin(sleep(duration))
-}
-
 pub mod future {
     use super::*;
 
-    /// Retries given `operation` according to the [`Backoff`] policy.
+    pub trait Sleeper {
+        type Sleep: Future<Output = ()> + Send + 'static;
+        fn sleep(&self, dur: Duration) -> Self::Sleep;
+    }
+
+    /// Retries given `operation` according to the [`Backoff`] policy
+    /// and waits between attempts using the passed [`Sleeper`].
     /// [`Backoff`] is reset before it is used.
+    ///
+    /// If you're using tokio or async_std, you may want to look at
+    /// [`backoff::tokio::retry`](tokio::retry) or [`backoff::async_std::retry`](async_std::retry)
     ///
     /// # Example
     ///
     /// ```rust
-    /// # #[cfg(feature = "async-std")]
-    /// # extern crate async_std_1 as async_std;
-    /// # #[cfg(feature = "tokio")]
-    /// # extern crate tokio_02 as tokio;
-    /// use backoff::{future, ExponentialBackoff};
+    /// # struct MySleeper;
+    /// # impl backoff::future::Sleeper for MySleeper {
+    /// #     type Sleep = std::future::Ready<()>;
+    /// #     fn sleep(&self, _dur: std::time::Duration) -> Self::Sleep { std::future::ready(()) }
+    /// # }
+    /// use backoff::ExponentialBackoff;
     ///
     /// async fn f() -> Result<(), backoff::Error<&'static str>> {
     ///     // Business logic...
     ///     Err(backoff::Error::Permanent("error"))
     /// }
     ///
-    /// # #[cfg_attr(feature = "async-std", async_std::main)]
-    /// # #[cfg_attr(feature = "tokio", tokio::main)]
-    /// # async fn main() {
-    /// future::retry(ExponentialBackoff::default(), f).await.err().unwrap();
+    /// # async fn go() {
+    /// backoff::future::retry(MySleeper, ExponentialBackoff::default(), f).await.err().unwrap();
     /// # }
+    /// # fn main() { futures_executor::block_on(go()); }
     /// ```
-    pub fn retry<I, E, Fn, B>(backoff: B, operation: Fn) -> Retry<B, NoopNotify, Fn, Fn::Fut>
+    pub fn retry<S, I, E, Fn, B>(
+        sleeper: S,
+        backoff: B,
+        operation: Fn,
+    ) -> Retry<S, B, NoopNotify, Fn, Fn::Fut>
     where
+        S: Sleeper,
         B: Backoff,
         Fn: FutureOperation<I, E>,
     {
-        retry_notify(backoff, operation, NoopNotify)
+        retry_notify(sleeper, backoff, operation, NoopNotify)
     }
 
-    /// Retries given `operation` according to the [`Backoff`] policy.
+    /// Retries given `operation` according to the [`Backoff`] policy
+    /// and waits between attempts using the passed [`Sleeper`].
     /// Calls `notify` on failed attempts (in case of [`Error::Transient`]).
     /// [`Backoff`] is reset before it is used.
+    ///
+    /// If you're using tokio or async_std, you may want to look at
+    /// [`backoff::tokio::retry_notify`] or [`backoff::async_std::retry_notify`]
     ///
     /// # Async `notify`
     ///
     /// `notify` can be neither `async fn` or [`Future`]. If you need to perform some async
-    /// operations inside `notify`, consider to use `tokio::spawn` or `async_std::task::spawn`
-    /// for that.
+    /// operations inside `notify`, consider using your runtimes task-spawning functionality.
     ///
     /// The reason behind this is that [`Retry`] future cannot be responsible for polling
     /// `notify` future, because can easily be dropped _before_ `notify` is completed.
@@ -78,32 +81,37 @@ pub mod future {
     /// # Example
     ///
     /// ```rust
-    /// # #[cfg(feature = "async-std")]
-    /// # extern crate async_std_1 as async_std;
-    /// # #[cfg(feature = "tokio")]
-    /// # extern crate tokio_02 as tokio;
-    /// use backoff::{future, backoff::Stop};
+    /// # struct MySleeper;
+    /// # impl backoff::future::Sleeper for MySleeper {
+    /// #     type Sleep = std::future::Ready<()>;
+    /// #     fn sleep(&self, _dur: std::time::Duration) -> Self::Sleep { std::future::ready(()) }
+    /// # }
+    /// use backoff::backoff::Stop;
     ///
     /// async fn f() -> Result<(), backoff::Error<&'static str>> {
     ///     // Business logic...
     ///     Err(backoff::Error::Transient("error"))
     /// }
     ///
-    /// # #[cfg_attr(feature = "async-std", async_std::main)]
-    /// # #[cfg_attr(feature = "tokio", tokio::main)]
-    /// # async fn main() {
-    /// future::retry_notify(Stop {}, f, |e, dur| println!("Error happened at {:?}: {}", dur, e))
-    ///     .await
-    ///     .err()
-    ///     .unwrap();
+    /// # async fn go() {
+    /// let err = backoff::future::retry_notify(MySleeper, Stop {}, f, |e, dur| {
+    ///     println!("Error happened at {:?}: {}", dur, e)
+    /// })
+    /// .await
+    /// .err()
+    /// .unwrap();
+    /// assert_eq!(err, "error");
     /// # }
+    /// # fn main() { futures_executor::block_on(go()); }
     /// ```
-    pub fn retry_notify<I, E, Fn, B, N>(
+    pub fn retry_notify<S, I, E, Fn, B, N>(
+        sleeper: S,
         mut backoff: B,
         mut operation: Fn,
         notify: N,
-    ) -> Retry<B, N, Fn, Fn::Fut>
+    ) -> Retry<S, B, N, Fn, Fn::Fut>
     where
+        S: Sleeper,
         B: Backoff,
         Fn: FutureOperation<I, E>,
         N: Notify<E>,
@@ -111,8 +119,9 @@ pub mod future {
         backoff.reset();
         let fut = operation.call_op();
         Retry {
+            sleeper,
             backoff,
-            delay: None,
+            delay: OptionPinned::None,
             operation,
             fut,
             notify,
@@ -130,84 +139,6 @@ pub mod future {
 
         /// Calls this [`FutureOperation`] returning a [`Future`] to be executed.
         fn call_op(&mut self) -> Self::Fut;
-
-        /// Retries this [`FutureOperation`] according to the [`Backoff`] policy.
-        /// [`Backoff`] is reset before it is used.
-        ///
-        /// # Example
-        ///
-        /// ```rust
-        /// # #[cfg(feature = "async-std")]
-        /// # extern crate async_std_1 as async_std;
-        /// # #[cfg(feature = "tokio")]
-        /// # extern crate tokio_02 as tokio;
-        /// use backoff::{future::FutureOperation as _, ExponentialBackoff};
-        ///
-        /// async fn f() -> Result<(), backoff::Error<&'static str>> {
-        ///     // Business logic...
-        ///     Err(backoff::Error::Permanent("error"))
-        /// }
-        ///
-        /// # #[cfg_attr(feature = "async-std", async_std::main)]
-        /// # #[cfg_attr(feature = "tokio", tokio::main)]
-        /// # async fn main() {
-        /// f.retry(ExponentialBackoff::default()).await.err().unwrap();
-        /// # }
-        /// ```
-        fn retry<B>(self, backoff: B) -> Retry<B, NoopNotify, Self, Self::Fut>
-        where
-            B: Backoff,
-            Self: Sized,
-        {
-            retry(backoff, self)
-        }
-
-        /// Retries this [`FutureOperation`] according to the [`Backoff`] policy.
-        /// Calls `notify` on failed attempts (in case of [`Error::Transient`]).
-        /// [`Backoff`] is reset before it is used.
-        ///
-        /// # Async `notify`
-        ///
-        /// `notify` can be neither `async fn` or [`Future`]. If you need to perform some async
-        /// operations inside `notify`, consider to use `tokio::spawn` or `async_std::task::spawn`
-        /// for that.
-        ///
-        /// The reason behind this is that [`Retry`] future cannot be responsible for polling
-        /// `notify` future, because can easily be dropped _before_ `notify` is completed.
-        /// So, considering the fact that most of the time no async operations are required in
-        /// `notify`, it's up to the caller to decide how async `notify` should be performed.
-        ///
-        /// # Example
-        ///
-        /// ```rust
-        /// # #[cfg(feature = "async-std")]
-        /// # extern crate async_std_1 as async_std;
-        /// # #[cfg(feature = "tokio")]
-        /// # extern crate tokio_02 as tokio;
-        /// use backoff::{future::FutureOperation as _, backoff::Stop};
-        ///
-        /// async fn f() -> Result<(), backoff::Error<&'static str>> {
-        ///     // Business logic...
-        ///     Err(backoff::Error::Transient("error"))
-        /// }
-        ///
-        /// # #[cfg_attr(feature = "async-std", async_std::main)]
-        /// # #[cfg_attr(feature = "tokio", tokio::main)]
-        /// # async fn main() {
-        /// f.retry_notify(Stop {}, |e, dur| println!("Error happened at {:?}: {}", dur, e))
-        ///     .await
-        ///     .err()
-        ///     .unwrap();
-        /// # }
-        /// ```
-        fn retry_notify<B, N>(self, backoff: B, notify: N) -> Retry<B, N, Self, Self::Fut>
-        where
-            B: Backoff,
-            N: Notify<E>,
-            Self: Sized,
-        {
-            retry_notify(backoff, self, notify)
-        }
     }
 
     impl<I, E, Fn, Fut> FutureOperation<I, E> for Fn
@@ -222,15 +153,20 @@ pub mod future {
         }
     }
 }
+use future::Sleeper;
 
 /// Retry implementation.
 #[pin_project]
-pub struct Retry<B, N, Fn, Fut> {
+pub struct Retry<S: Sleeper, B, N, Fn, Fut> {
+    /// The [`Sleeper`] that we generate the `delay` futures from.
+    sleeper: S,
+
     /// [`Backoff`] implementation to count next [`Retry::delay`] with.
     backoff: B,
 
     /// [`Future`] which delays execution before next [`Retry::operation`] invocation.
-    delay: Option<Sleep>,
+    #[pin]
+    delay: OptionPinned<S::Sleep>,
 
     /// Operation to be retried. It must return [`Future`].
     operation: Fn,
@@ -243,8 +179,15 @@ pub struct Retry<B, N, Fn, Fut> {
     notify: N,
 }
 
-impl<B, N, Fn, Fut, I, E> Future for Retry<B, N, Fn, Fut>
+#[pin_project(project = OptionProj)]
+enum OptionPinned<T> {
+    Some(#[pin] T),
+    None,
+}
+
+impl<S, B, N, Fn, Fut, I, E> Future for Retry<S, B, N, Fn, Fut>
 where
+    S: Sleeper,
     B: Backoff,
     N: Notify<E>,
     Fn: FnMut() -> Fut,
@@ -256,9 +199,9 @@ where
         let mut this = self.project();
 
         loop {
-            if this.delay.is_some() {
-                ready!(Pin::new(this.delay.as_mut().unwrap()).poll(cx));
-                let _ = this.delay.take();
+            if let OptionProj::Some(delay) = this.delay.as_mut().project() {
+                ready!(delay.poll(cx));
+                this.delay.set(OptionPinned::None);
             }
 
             match ready!(this.fut.as_mut().poll(cx)) {
@@ -267,7 +210,8 @@ where
                 Err(Error::Transient(e)) => match this.backoff.next_backoff() {
                     Some(duration) => {
                         this.notify.notify(e, duration);
-                        this.delay.replace(sleep(duration));
+                        this.delay
+                            .set(OptionPinned::Some(this.sleeper.sleep(duration)));
                         this.fut.set((this.operation)());
                     }
                     None => return Poll::Ready(Err(e)),
@@ -276,3 +220,137 @@ where
         }
     }
 }
+
+// runtime-specific convenience modules
+
+macro_rules! doc_comment {
+    ($x:expr, $($tt:tt)*) => {
+        #[doc = $x]
+        $($tt)*
+    };
+}
+
+macro_rules! gen_rt_module {
+    ($rt:ident, $rt_crate:ident, $Sleeper:ident, feature = $feat:literal) => {
+        #[cfg(feature = $feat)]
+        pub mod $rt {
+            use super::*;
+            use future::FutureOperation;
+
+            doc_comment! {
+                concat!("Retries given `operation` according to the [`Backoff`] policy.
+[`Backoff`] is reset before it is used.
+
+The returned future can be spawned onto a ",stringify!($rt),"-compatible runtime.
+
+# Example
+
+```rust
+# extern crate ",stringify!($rt_crate)," as ",stringify!($rt),r#";
+use backoff::ExponentialBackoff;
+
+async fn f() -> Result<(), backoff::Error<&'static str>> {
+    // Business logic...
+    Err(backoff::Error::Permanent("error"))
+}
+
+# #["#,stringify!($rt),"::main]
+# async fn main() {
+let err = backoff::",stringify!($rt),r#"::retry(ExponentialBackoff::default(), f).await.err().unwrap();
+assert_eq!(err, "error");
+# }
+```"#),
+                pub fn retry<I, E, Fn, B>(
+                    backoff: B,
+                    operation: Fn,
+                ) -> Retry<impl Sleeper, B, NoopNotify, Fn, Fn::Fut>
+                where
+                    B: Backoff,
+                    Fn: FutureOperation<I, E>,
+                {
+                    future::retry($Sleeper, backoff, operation)
+                }
+            }
+
+            doc_comment! {
+                concat!("Retries given `operation` according to the [`Backoff`] policy.
+Calls `notify` on failed attempts (in case of [`Error::Transient`]).
+[`Backoff`] is reset before it is used.
+
+The returned future can be spawned onto a ",stringify!($rt),"-compatible runtime.
+
+# Async `notify`
+
+`notify` can be neither `async fn` or [`Future`]. If you need to perform some async
+operations inside `notify`, consider using `",stringify!($rt),r"::task::spawn` for that.
+
+The reason behind this is that [`Retry`] future cannot be responsible for polling
+`notify` future, because can easily be dropped _before_ `notify` is completed.
+So, considering the fact that most of the time no async operations are required in
+`notify`, it's up to the caller to decide how async `notify` should be performed.
+
+# Example
+
+```rust
+# extern crate ",stringify!($rt_crate)," as ",stringify!($rt),r#";
+use backoff::ExponentialBackoff;
+use backoff::backoff::Stop;
+
+async fn f() -> Result<(), backoff::Error<&'static str>> {
+    // Business logic...
+    Err(backoff::Error::Transient("error"))
+}
+
+# #["#,stringify!($rt),"::main]
+# async fn main() {
+backoff::",stringify!($rt),r#"::retry_notify(Stop {}, f, |e, dur| println!("Error happened at {:?}: {}", dur, e))
+    .await
+    .err()
+    .unwrap();
+# }
+```"#),
+                pub fn retry_notify<I, E, Fn, B, N>(
+                    backoff: B,
+                    operation: Fn,
+                    notify: N,
+                ) -> Retry<impl Sleeper, B, N, Fn, Fn::Fut>
+                where
+                    B: Backoff,
+                    Fn: FutureOperation<I, E>,
+                    N: Notify<E>,
+                {
+                    future::retry_notify($Sleeper, backoff, operation, notify)
+                }
+            }
+        }
+    };
+}
+
+#[cfg(feature = "tokio")]
+struct TokioSleeper;
+#[cfg(feature = "tokio")]
+impl Sleeper for TokioSleeper {
+    type Sleep = ::tokio_1::time::Sleep;
+    fn sleep(&self, dur: Duration) -> Self::Sleep {
+        ::tokio_1::time::sleep(dur)
+    }
+}
+
+gen_rt_module!(tokio, tokio_1, TokioSleeper, feature = "tokio");
+
+#[cfg(feature = "async-std")]
+struct AsyncStdSleeper;
+#[cfg(feature = "async-std")]
+impl Sleeper for AsyncStdSleeper {
+    type Sleep = Pin<Box<dyn Future<Output = ()> + Send + 'static>>;
+    fn sleep(&self, dur: Duration) -> Self::Sleep {
+        Box::pin(::async_std_1::task::sleep(dur))
+    }
+}
+
+gen_rt_module!(
+    async_std,
+    async_std_1,
+    AsyncStdSleeper,
+    feature = "async-std"
+);


### PR DESCRIPTION
I realized that the conditional compilation for `fn sleep() -> Sleep` in `async.rs` could be represented as a trait, so I did this. I'm not too sure about the names.

This allows for accessing both the async_std and tokio versions of the retry functions if so desired, and also lets you implement your own sleeper if you use some other runtime.
