### PR TITLE
Update to rand 0.8, remove stdweb feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,8 @@ async_std_1 = { package = "async-std", version = "1.8", optional = true }
 futures-core = { version = "0.3.8", default-features = false, optional = true }
 instant = "0.1"
 pin-project = { version = "1.0", optional = true }
-rand = "0.7"
+rand = "0.8"
+getrandom = "0.2"
 tokio_1 = { package = "tokio", version = "1.0", features = ["time"], optional = true }
 
 [dev-dependencies]
@@ -32,8 +33,7 @@ futures-executor = "0.3"
 
 [features]
 default = []
-stdweb = ["instant/stdweb", "rand/stdweb"]
-wasm-bindgen = ["instant/wasm-bindgen", "rand/wasm-bindgen"]
+wasm-bindgen = ["instant/wasm-bindgen", "getrandom/js"]
 futures = ["futures-core", "pin-project"]
 tokio = ["futures", "tokio_1"]
 async-std = ["futures", "async_std_1"]


### PR DESCRIPTION
It seems that rand 0.8 no longer supports stdweb, but stdweb (but not `cargo web`) is compatible with wasm-bindgen, so this may not be too much of an issue.
