### PR TITLE
refact: make retry and retry_notify take ownership of Backoff values

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,44 +60,27 @@ async fn fetch_url(url: &str) -> Result<String, reqwest::Error> {
 
 #### Removal of Operation trait
 
-The `Operation` trait has been removed, please use normal closures implementing `FnMut` instead. The `retry` and `retry_notify` methods were converted to free functions, available in the crate's root:  
+https://github.com/ihrwein/backoff/pull/28
 
-```diff
--let mut op = || {
-+let op = || {
-     println!("Fetching {}", url);
-     let mut resp = reqwest::get(url)?;
-     ...
- };
- 
- let mut backoff = ExponentialBackoff::default();
--op.retry(&mut backoff)
-+retry(&mut backoff, op)
-```
+The `Operation` trait has been removed, please use normal closures implementing `FnMut` instead. The `retry` and `retry_notify` methods were converted to free functions, available in the crate's root.
+
+[Example](examples/retry.rs).
 
 #### Removal of FutureOperation trait
 
-The `FutureOperation` trait has been removed. The `retry` and `retry_notify` methods were converted to free functions, available in the crate's root:
+https://github.com/ihrwein/backoff/pull/28
 
-```diff
+The `FutureOperation` trait has been removed. The `retry` and `retry_notify` methods were converted to free functions, available in the crate's root.
 
-+extern crate tokio_1 as tokio;
-+
-+use backoff::ExponentialBackoff;
- 
- async fn fetch_url(url: &str) -> Result<String, reqwest::Error> {
--    (|| async {
-+    backoff::tokio::retry(ExponentialBackoff::default(), || async {
-         Ok(reqwest::get(url).await?.text().await?)
-     })
--    .retry(ExponentialBackoff::default())
-     .await
- }
-```
+[Example](examples/async.rs).
 
 #### Changes in feature flags
 
 * `stdweb` flag was removed, as the project is abandoned.
+
+#### `retry`, `retry_notify` taking ownership of Backoff instances (previously &mut)
+
+[Example](examples/retry.rs).
 
 ## License
 

--- a/examples/permanent_error.rs
+++ b/examples/permanent_error.rs
@@ -27,8 +27,8 @@ fn fetch_url(url: &str) -> Result<String, Error<io::Error>> {
         Ok(content)
     };
 
-    let mut backoff = ExponentialBackoff::default();
-    backoff::retry(&mut backoff, op)
+    let backoff = ExponentialBackoff::default();
+    backoff::retry(backoff, op)
 }
 
 fn main() {

--- a/examples/retry.rs
+++ b/examples/retry.rs
@@ -12,8 +12,8 @@ fn fetch_url(url: &str) -> Result<String, Error<reqwest::Error>> {
         Ok(content)
     };
 
-    let mut backoff = ExponentialBackoff::default();
-    retry(&mut backoff, op)
+    let backoff = ExponentialBackoff::default();
+    retry(backoff, op)
 }
 
 fn main() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -87,8 +87,8 @@
 //!         Ok(content)
 //!     };
 //!
-//!     let mut backoff = ExponentialBackoff::default();
-//!     backoff::retry(&mut backoff, op)
+//!     let backoff = ExponentialBackoff::default();
+//!     backoff::retry(backoff, op)
 //! }
 //!
 //! fn main() {
@@ -121,8 +121,8 @@
 //!         Ok(content)
 //!     };
 //!
-//!     let mut backoff = ExponentialBackoff::default();
-//!     retry(&mut backoff, op)
+//!     let backoff = ExponentialBackoff::default();
+//!     retry(backoff, op)
 //! }
 //!
 //! fn main() {

--- a/tests/retry.rs
+++ b/tests/retry.rs
@@ -23,8 +23,8 @@ fn retry() {
             )))
         };
 
-        let mut backoff = ExponentialBackoff::default();
-        backoff::retry(&mut backoff, f).ok().unwrap();
+        let backoff = ExponentialBackoff::default();
+        backoff::retry(backoff, f).ok().unwrap();
     }
 
     assert_eq!(i, success_on);
@@ -39,8 +39,8 @@ fn permanent_error_immediately_returned() {
         )))
     };
 
-    let mut backoff = ExponentialBackoff::default();
-    match backoff::retry(&mut backoff, f).err().unwrap() {
+    let backoff = ExponentialBackoff::default();
+    match backoff::retry(backoff, f).err().unwrap() {
         Error::Permanent(_) => (),
         other => panic!("{}", other),
     }


### PR DESCRIPTION
Also extract retry logic into a type. It might be made public in the future.