### PR TITLE
Add builder for ExponentialBackoff

### DIFF
--- a/src/exponential.rs
+++ b/src/exponential.rs
@@ -1,4 +1,5 @@
 use instant::Instant;
+use std::marker::PhantomData;
 use std::time::Duration;
 
 use crate::backoff::Backoff;
@@ -9,7 +10,7 @@ use crate::default;
 pub struct ExponentialBackoff<C> {
     /// The current retry interval.
     pub current_interval: Duration,
-    ///  The initial retry interval.
+    /// The initial retry interval.
     pub initial_interval: Duration,
     /// The randomization factor to use for creating a range around the retry interval.
     ///
@@ -24,7 +25,7 @@ pub struct ExponentialBackoff<C> {
     /// The system time. It is calculated when an [`ExponentialBackoff`](struct.ExponentialBackoff.html) instance is
     /// created and is reset when [`retry`](../trait.Operation.html#method.retry) is called.
     pub start_time: Instant,
-    ///  The maximum elapsed time after instantiating [`ExponentialBackfff`](struct.ExponentialBackoff.html) or calling
+    /// The maximum elapsed time after instantiating [`ExponentialBackfff`](struct.ExponentialBackoff.html) or calling
     /// [`reset`](trait.Backoff.html#method.reset) after which [`next_backoff`](../trait.Backoff.html#method.reset) returns `None`.
     pub max_elapsed_time: Option<Duration>,
     /// The clock used to get the current time.
@@ -134,6 +135,89 @@ where
     }
 }
 
+/// Builder for [`ExponentialBackoff`](type.ExponentialBackoff.html).
+///
+/// TODO: Example
+#[derive(Debug)]
+pub struct ExponentialBackoffBuilder<C> {
+    initial_interval: Duration,
+    randomization_factor: f64,
+    multiplier: f64,
+    max_interval: Duration,
+    max_elapsed_time: Option<Duration>,
+    _clock: PhantomData<C>,
+}
+
+impl<C> Default for ExponentialBackoffBuilder<C> {
+    fn default() -> Self {
+        Self {
+            initial_interval: Duration::from_millis(default::INITIAL_INTERVAL_MILLIS),
+            randomization_factor: default::RANDOMIZATION_FACTOR,
+            multiplier: default::MULTIPLIER,
+            max_interval: Duration::from_millis(default::MAX_INTERVAL_MILLIS),
+            max_elapsed_time: Some(Duration::from_millis(default::MAX_ELAPSED_TIME_MILLIS)),
+            _clock: PhantomData,
+        }
+    }
+}
+
+impl<C> ExponentialBackoffBuilder<C>
+where
+    C: Clock + Default,
+{
+    pub fn new() -> Self {
+        Default::default()
+    }
+
+    /// The initial retry interval.
+    pub fn with_initial_interval(&mut self, initial_interval: Duration) -> &mut Self {
+        self.initial_interval = initial_interval;
+        self
+    }
+
+    /// The randomization factor to use for creating a range around the retry interval.
+    ///
+    /// A randomization factor of 0.5 results in a random period ranging between 50% below and 50%
+    /// above the retry interval.
+    pub fn with_randomization_factor(&mut self, randomization_factor: f64) -> &mut Self {
+        self.randomization_factor = randomization_factor;
+        self
+    }
+
+    /// The value to multiply the current interval with for each retry attempt.
+    pub fn with_multiplier(&mut self, multiplier: f64) -> &mut Self {
+        self.multiplier = multiplier;
+        self
+    }
+
+    /// The maximum value of the back off period. Once the retry interval reaches this
+    /// value it stops increasing.
+    pub fn with_max_interval(&mut self, max_interval: Duration) -> &mut Self {
+        self.max_interval = max_interval;
+        self
+    }
+
+    /// The maximum elapsed time after instantiating [`ExponentialBackfff`](struct.ExponentialBackoff.html) or calling
+    /// [`reset`](trait.Backoff.html#method.reset) after which [`next_backoff`](../trait.Backoff.html#method.reset) returns `None`.
+    pub fn with_max_elapsed_time(&mut self, max_elapsed_time: Option<Duration>) -> &mut Self {
+        self.max_elapsed_time = max_elapsed_time;
+        self
+    }
+
+    pub fn build(&self) -> ExponentialBackoff<C> {
+        ExponentialBackoff {
+            current_interval: self.initial_interval,
+            initial_interval: self.initial_interval,
+            randomization_factor: self.randomization_factor,
+            multiplier: self.multiplier,
+            max_interval: self.max_interval,
+            max_elapsed_time: self.max_elapsed_time,
+            clock: C::default(),
+            start_time: Instant::now(),
+        }
+    }
+}
+
 #[cfg(test)]
 use crate::clock::SystemClock;
 
@@ -149,4 +233,48 @@ fn get_randomized_interval() {
     // 33% chance of being 3.
     assert_eq!(Duration::new(0, 3), f(0.5, 0.67, Duration::new(0, 2)));
     assert_eq!(Duration::new(0, 3), f(0.5, 0.99, Duration::new(0, 2)));
+}
+
+#[test]
+fn exponential_backoff_builder() {
+    let initial_interval = Duration::from_secs(1);
+    let max_interval = Duration::from_secs(2);
+    let multiplier = 3.0;
+    let randomization_factor = 4.0;
+    let backoff: ExponentialBackoff<SystemClock> = ExponentialBackoffBuilder::new()
+        .with_initial_interval(initial_interval)
+        .with_multiplier(multiplier)
+        .with_randomization_factor(randomization_factor)
+        .with_max_interval(max_interval)
+        .with_max_elapsed_time(None)
+        .build();
+    assert_eq!(backoff.initial_interval, initial_interval);
+    assert_eq!(backoff.current_interval, initial_interval);
+    assert_eq!(backoff.multiplier, multiplier);
+    assert_eq!(backoff.randomization_factor, randomization_factor);
+    assert_eq!(backoff.max_interval, max_interval);
+    assert_eq!(backoff.max_elapsed_time, None);
+}
+
+#[test]
+fn exponential_backoff_default_builder() {
+    let backoff: ExponentialBackoff<SystemClock> = ExponentialBackoffBuilder::new().build();
+    assert_eq!(
+        backoff.initial_interval,
+        Duration::from_millis(default::INITIAL_INTERVAL_MILLIS)
+    );
+    assert_eq!(
+        backoff.current_interval,
+        Duration::from_millis(default::INITIAL_INTERVAL_MILLIS)
+    );
+    assert_eq!(backoff.multiplier, default::MULTIPLIER);
+    assert_eq!(backoff.randomization_factor, default::RANDOMIZATION_FACTOR);
+    assert_eq!(
+        backoff.max_interval,
+        Duration::from_millis(default::MAX_INTERVAL_MILLIS)
+    );
+    assert_eq!(
+        backoff.max_elapsed_time,
+        Some(Duration::from_millis(default::MAX_ELAPSED_TIME_MILLIS))
+    );
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -231,3 +231,6 @@ pub use crate::retry::{retry, retry_notify, Notify};
 /// `exponential::ExponentialBackoff` as it is generic over any [Clocks](trait.Clock.html)
 /// and in the real world mostly system's clock is used.
 pub type ExponentialBackoff = exponential::ExponentialBackoff<SystemClock>;
+
+/// Builder for exponential backoff policy with system's clock.
+pub type ExponentialBackoffBuilder = exponential::ExponentialBackoffBuilder<SystemClock>;


### PR DESCRIPTION
We've recently ran into a subtle issue when using `ExponentialBackoff` through `Backoff` trait and not `retry` function. Namely, we've set "public" `initial_interval` field but not the "private" `current_interval` field, which then was left with the default 500ms value, which made us scratch our heads about why the first backoff interval is always that long. A call to `reset` solves that, but it is not obvious from the documentation that it's required in this case.

While as far as I understand the primary use case is through the `retry` function, it would still be nice to make it "harder" to use the crate incorrectly. The proposal is to introduce a builder which would only set the fields that are intended to be public and not part of the state, and suggest the users to create instances of `ExponentialBackoff` through the builder in documentation.

If the proposal makes sense, I can also later update the documentation.