### PR TITLE
allow manually set retry timeout

### DIFF
--- a/tests/retry.rs
+++ b/tests/retry.rs
@@ -17,10 +17,10 @@ fn retry() {
                 return Ok(());
             }
 
-            Err(Error::Transient(io::Error::new(
-                io::ErrorKind::Other,
-                "err",
-            )))
+            Err(Error::Transient(
+                io::Error::new(io::ErrorKind::Other, "err"),
+                None,
+            ))
         };
 
         let backoff = ExponentialBackoff::default();


### PR DESCRIPTION
I've added an `Option<Duration>` to `Error<E>::Transient`, if not `None` the retry logic will use the given duration for the next retry instead of the value derived from the backup policy. This allows users to handle ratelimits like a http 429 response. Resolves #35