### PR TITLE
Replace pin-project with pin-project-lite

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ travis-ci = { repository = "ihrwein/backoff" }
 async_std_1 = { package = "async-std", version = "1.9", optional = true }
 futures-core = { version = "0.3.8", default-features = false, optional = true }
 instant = "0.1"
-pin-project = { version = "1.0", optional = true }
+pin-project-lite = { version = "0.2.7", optional = true }
 rand = "0.8"
 getrandom = "0.2"
 tokio_1 = { package = "tokio", version = "1.0", features = ["time"], optional = true }
@@ -34,7 +34,7 @@ futures-executor = "0.3"
 [features]
 default = []
 wasm-bindgen = ["instant/wasm-bindgen", "getrandom/js"]
-futures = ["futures-core", "pin-project"]
+futures = ["futures-core", "pin-project-lite"]
 tokio = ["futures", "tokio_1"]
 async-std = ["futures", "async_std_1"]
 


### PR DESCRIPTION
Unfortunately, I had to change some doc-comments to regular comments due to https://github.com/taiki-e/pin-project-lite/issues/3. Fortunately, those fields are private and wouldn't show up in documentation anyways (unless rustdoc is used with `--document-private-items`).