### PR TITLE
Make SystemClock Clone to make ExponentialBackoff Clone

### DIFF
--- a/src/clock.rs
+++ b/src/clock.rs
@@ -7,7 +7,7 @@ pub trait Clock {
 
 /// `SystemClock` uses the system's clock to get the current time.
 /// This Clock should be used for real use-cases.
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Clone)]
 pub struct SystemClock {}
 
 impl Clock for SystemClock {


### PR DESCRIPTION
Continuation of #19 .

Very helpful for application wishing to share the same backoff strategy. Avoids errors described in https://github.com/kube-rs/kube-rs/pull/703#issuecomment-966633046