### PR TITLE
Support `tokio::time::Instant` in `SystemClock`

### DIFF
--- a/.github/workflows/check_pr.yml
+++ b/.github/workflows/check_pr.yml
@@ -13,6 +13,7 @@ jobs:
         feature:
           - async-std
           - futures
+          - instant
           - tokio
           - wasm-bindgen
     steps:
@@ -27,10 +28,10 @@ jobs:
           override: true
 
       - name: Run cargo check
-        run: cargo check --features=${{ matrix.feature }}
+        run: cargo check --no-default-features --features=${{ matrix.feature }}
 
       - name: Run cargo test
-        run: cargo test --features=${{ matrix.feature }}
+        run: cargo test --no-default-features --features=${{ matrix.feature }}
 
   lints:
     name: Lints

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ travis-ci = { repository = "ihrwein/backoff" }
 [dependencies]
 async_std_1 = { package = "async-std", version = "1.9", optional = true }
 futures-core = { version = "0.3.8", default-features = false, optional = true }
-instant = "0.1"
+instant = { version = "0.1", optional = true }
 pin-project-lite = { version = "0.2.7", optional = true }
 rand = "0.8"
 getrandom = "0.2"
@@ -32,7 +32,7 @@ tokio_1 = { package = "tokio", version = "1.0", features = ["macros", "time", "r
 futures-executor = "0.3"
 
 [features]
-default = []
+default = ["instant"]
 wasm-bindgen = ["instant/wasm-bindgen", "getrandom/js"]
 futures = ["futures-core", "pin-project-lite"]
 tokio = ["futures", "tokio_1"]

--- a/src/clock.rs
+++ b/src/clock.rs
@@ -1,4 +1,4 @@
-use instant::Instant;
+use crate::Instant;
 
 /// Clock returns the current time.
 pub trait Clock {

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,7 +1,6 @@
 use std::error;
 use std::fmt;
-
-use instant::Duration;
+use std::time::Duration;
 
 /// Error is the error value in an operation's
 /// result.

--- a/src/exponential.rs
+++ b/src/exponential.rs
@@ -1,10 +1,10 @@
-use instant::Instant;
 use std::marker::PhantomData;
 use std::time::Duration;
 
 use crate::backoff::Backoff;
 use crate::clock::Clock;
 use crate::default;
+use crate::Instant;
 
 #[derive(Debug)]
 pub struct ExponentialBackoff<C> {

--- a/src/instant.rs
+++ b/src/instant.rs
@@ -1,0 +1,8 @@
+#[cfg(feature = "instant")]
+pub use instant::Instant;
+
+#[cfg(all(feature = "tokio_1", not(feature = "instant")))]
+pub use tokio_1::time::Instant;
+
+#[cfg(not(any(feature = "tokio_1", feature = "instant")))]
+pub use std::time::Instant;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -216,6 +216,7 @@ pub mod backoff;
 mod clock;
 pub mod default;
 mod error;
+mod instant;
 pub mod exponential;
 
 #[cfg(feature = "futures")]
@@ -226,6 +227,7 @@ mod retry;
 
 pub use crate::clock::{Clock, SystemClock};
 pub use crate::error::Error;
+pub use crate::instant::Instant;
 pub use crate::retry::{retry, retry_notify, Notify};
 
 /// Exponential backoff policy with system's clock.

--- a/tests/exponential.rs
+++ b/tests/exponential.rs
@@ -1,11 +1,9 @@
 extern crate backoff;
-extern crate instant;
 
 use backoff::backoff::Backoff;
 use backoff::exponential::ExponentialBackoff;
-use backoff::{Clock, SystemClock};
+use backoff::{Clock, Instant, SystemClock};
 
-use instant::Instant;
 use std::cell::RefCell;
 use std::time::Duration;
 


### PR DESCRIPTION
`tokio::time::Instant` is a special `Instant` type that supports mocking
for tests (via [`tokio::time::pause`][pause]). Furthermore, it [avoids
panics][panic] in `Instant` arithmetic.

When using `tokio::time::Instant`, there's no need for a dependency on
the `instant` crate.

This change:

* makes the `instant` crate an optional dependency, enabled by default;
* uses `tokio::time::Instant` when the `tokio_1` feature is enabled and
  `instant` is not; and
* uses `std::time::Instant` when neither of these features are enabled.

The type is exposed publicly via `backoff::Instant` as a convenience.

This change is backwards-compatible and does not alter the default
behavior.

[pause]: https://docs.rs/tokio/latest/tokio/time/fn.pause.html
[panic]: https://github.com/tokio-rs/tokio/pull/4461