### PR TITLE
refactor(instant): Make instant an optional dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ travis-ci = { repository = "ihrwein/backoff" }
 [dependencies]
 async_std_1 = { package = "async-std", version = "1.9", optional = true }
 futures-core = { version = "0.3.8", default-features = false, optional = true }
-instant = "0.1"
+instant = { version = "0.1", optional = true }
 pin-project-lite = { version = "0.2.7", optional = true }
 rand = "0.8"
 getrandom = "0.2"
@@ -32,8 +32,9 @@ tokio_1 = { package = "tokio", version = "1.0", features = ["macros", "time", "r
 futures-executor = "0.3"
 
 [features]
-default = []
-wasm-bindgen = ["instant/wasm-bindgen", "getrandom/js"]
+default = ["instant"]
+instant = ["dep:instant"]
+wasm-bindgen = ["instant", "instant/wasm-bindgen", "getrandom/js"]
 futures = ["futures-core", "pin-project-lite"]
 tokio = ["futures", "tokio_1"]
 async-std = ["futures", "async_std_1"]

--- a/src/clock.rs
+++ b/src/clock.rs
@@ -1,4 +1,4 @@
-use instant::Instant;
+use crate::instant::Instant;
 
 /// Clock returns the current time.
 pub trait Clock {

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,7 +1,7 @@
 use std::error;
 use std::fmt;
 
-use instant::Duration;
+use std::time::Duration;
 
 /// Error is the error value in an operation's
 /// result.

--- a/src/exponential.rs
+++ b/src/exponential.rs
@@ -1,10 +1,10 @@
-use instant::Instant;
 use std::marker::PhantomData;
 use std::time::Duration;
 
 use crate::backoff::Backoff;
 use crate::clock::Clock;
 use crate::default;
+use crate::instant::Instant;
 
 #[derive(Debug)]
 pub struct ExponentialBackoff<C> {

--- a/src/instant.rs
+++ b/src/instant.rs
@@ -1,0 +1,4 @@
+#[cfg(feature = "instant")]
+pub use instant::Instant;
+#[cfg(not(feature = "instant"))]
+pub use std::time::Instant;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -217,6 +217,7 @@ mod clock;
 pub mod default;
 mod error;
 pub mod exponential;
+pub mod instant;
 
 #[cfg(feature = "futures")]
 #[cfg_attr(docsrs, doc(cfg(feature = "futures")))]

--- a/tests/exponential.rs
+++ b/tests/exponential.rs
@@ -1,11 +1,10 @@
 extern crate backoff;
-extern crate instant;
 
 use backoff::backoff::Backoff;
 use backoff::exponential::ExponentialBackoff;
+use backoff::instant::Instant;
 use backoff::{Clock, SystemClock};
 
-use instant::Instant;
 use std::cell::RefCell;
 use std::time::Duration;
 


### PR DESCRIPTION
The `instant` crate is used by `backoff` to support the `Instant` type when compiling to WASM, but it is **currently unmaintained**. This PR makes the dependency optional, so that clients that do not need this feature can avoid taking the dependency.

The feature is enabled by default so this change should not be breaking, but it allows downstream packages to disable default features if they don't need to take the dependency.

A separate PR is required to change the dependency to something like `web-time` that is currently maintained.

## Test plan

Ran tests with and without the feature enabled:

```
cargo nextest run
cargo nextest run --no-default-features
cargo nextest run --no-default-features --features wasm-bindgen
cargo nextest run --features wasm-bindgen
```